### PR TITLE
fix: clicking back doesn't re query search

### DIFF
--- a/src/components/document-viewer.tsx
+++ b/src/components/document-viewer.tsx
@@ -153,7 +153,8 @@ function DocumentViewer(props: { id: number }) {
           </div>
           <div className="flex flex-shrink-0 flex-col">
             <Button
-              onClick={() => {
+              onClick={(e) => {
+                e.preventDefault();
                 router.back();
               }}
             >

--- a/src/components/document-viewer.tsx
+++ b/src/components/document-viewer.tsx
@@ -52,8 +52,6 @@ function SkeletonLoader() {
     },
   });
 
-  console.log(advice?.slip);
-
   return (
     <div className="flex h-4/5 w-full justify-center">
       <div className="flex h-full min-w-0 justify-center md:w-1/2">


### PR DESCRIPTION
### TL;DR

Fixes a bug where when you would exit a modal, it would serach for the query below the modal even though nothing changed.

### What changed?
I use prevent default on the button to only make it go browser back, not rerender after clicking.

### Why?
This gives a better user experience and less load on the server. 