### PR TITLE
fix: format failed to get document text

### DIFF
--- a/src/components/document-viewer.tsx
+++ b/src/components/document-viewer.tsx
@@ -128,8 +128,16 @@ function DocumentViewer(props: { id: number }) {
     return <SkeletonLoader />;
   }
 
-  if (!pdfUrl) {
-    return <h1>Failed to get document</h1>;
+  if (pdfUrl) {
+    return (
+      <div className="flex justify-center">
+        <div className="mx-auto max-w-sm rounded-lg bg-black p-4 shadow-md">
+          <h1 className="w-full text-center text-2xl font-bold">
+            Failed to get document
+          </h1>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/src/components/document-viewer.tsx
+++ b/src/components/document-viewer.tsx
@@ -128,7 +128,7 @@ function DocumentViewer(props: { id: number }) {
     return <SkeletonLoader />;
   }
 
-  if (pdfUrl) {
+  if (!pdfUrl) {
     return (
       <div className="flex justify-center">
         <div className="mx-auto max-w-sm rounded-lg bg-black p-4 shadow-md">


### PR DESCRIPTION
### TL;DR

This fixes the broken formatting of the error when the pdf doesn't load. 

### What changed?
- Updated the `document-viewer.tsx` component to display an error message with styling when a document fails to load

### Why?

The previous error message was unstyled and not very user-friendly. This update improves the user experience when a document fails to load.