### PR TITLE
fix: properly redirect back to earlier page after clicking sign in

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
-    "dev": "next dev",
+    "dev": "next dev --turbo",
     "lint": "next lint",
     "start": "next start"
   },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,6 @@ export default function HomePage() {
           </OpenExternalLink>{" "}
           to get started.
         </div>
-        <div>Or sign in to access the dashboard.</div>
       </div>
     </main>
   );

--- a/src/app/paperless/page.tsx
+++ b/src/app/paperless/page.tsx
@@ -160,7 +160,10 @@ export default function PaperlessPage() {
       <div className="flex flex-col items-center justify-center">
         <SignedOut>
           <div className="text-center text-2xl">
-            Please <OpenInternalLink href="/sign-in">sign in</OpenInternalLink>
+            Please{" "}
+            <OpenInternalLink href="/sign-in?redirect=/paperless">
+              sign in
+            </OpenInternalLink>
           </div>
         </SignedOut>
         <SignedIn>

--- a/src/app/whishper/page.tsx
+++ b/src/app/whishper/page.tsx
@@ -312,7 +312,10 @@ export default function WhishperPage() {
       <div className="flex flex-col items-center justify-center">
         <SignedOut>
           <div className="text-center text-2xl">
-            Please <OpenInternalLink href="/sign-in">sign in</OpenInternalLink>
+            Please{" "}
+            <OpenInternalLink href="/sign-in?redirect=/whishper">
+              sign in
+            </OpenInternalLink>
           </div>
         </SignedOut>
         <SignedIn>


### PR DESCRIPTION
Fixes #82

### TL;DR

When going to paperless and whishper and clicking sign in on that page, it should go back to that page after signing in